### PR TITLE
WASM support

### DIFF
--- a/packages/vorbis_rs/Cargo.toml
+++ b/packages/vorbis_rs/Cargo.toml
@@ -33,6 +33,7 @@ getrandom = { version = "0.3.0", features = ["std"], optional = true }
 [features]
 default = ["stream-serial-rng"]
 stream-serial-rng = ["dep:getrandom"]
+wasm-js = ["getrandom?/wasm_js"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/packages/vorbis_rs/src/lib.rs
+++ b/packages/vorbis_rs/src/lib.rs
@@ -23,6 +23,9 @@
 //!                       method, which automatically configures such a builder with suitable random
 //!                       Ogg stream serial numbers. This feature pulls dependencies on random number
 //!                       generation crates.
+//! - `wasm-js`           Enables the 'wasm_js' feature flag on [getrandom](https://crates.io/crates/getrandom).
+//!                       Used to enable [WebAssembly support](https://docs.rs/getrandom/latest/getrandom/#webassembly-support)
+//!                       for JavaScript environments.
 //!
 //! # Examples
 //!

--- a/packages/vorbis_rs/src/lib.rs
+++ b/packages/vorbis_rs/src/lib.rs
@@ -20,12 +20,14 @@
 //! # Features
 //!
 //! - `stream-serial-rng` (enabled by default): adds the [`VorbisEncoderBuilder::new`] convenience
-//!                       method, which automatically configures such a builder with suitable random
-//!                       Ogg stream serial numbers. This feature pulls dependencies on random number
-//!                       generation crates.
-//! - `wasm-js`           Enables the 'wasm_js' feature flag on [getrandom](https://crates.io/crates/getrandom).
-//!                       Used to enable [WebAssembly support](https://docs.rs/getrandom/latest/getrandom/#webassembly-support)
-//!                       for JavaScript environments.
+//!   method, which automatically configures such a builder with suitable random
+//!   Ogg stream serial numbers. This feature pulls dependencies on random number
+//!   generation crates.
+//! - `wasm-js`: enhances the ergonomics of using `vorbis_rs` when targeting JavaScript environments
+//!   with WebAssembly. Currently, this enables the `wasm_js` feature flag on
+//!   [`getrandom`](https://crates.io/crates/getrandom), opting into its [WebAssembly
+//!   support](https://docs.rs/getrandom/latest/getrandom/#webassembly-support) for JavaScript
+//!   environments, but the concrete effects of this flag may change at any point in the future.
 //!
 //! # Examples
 //!


### PR DESCRIPTION
- Trying to build a crate for WASM that depends on `vorbis_rs`
- `vorbis_rs` depends on `getrandom`
- To enable wasm support for `getrandom`, I have to follow the steps in this [documentation](https://docs.rs/getrandom/#webassembly-support), which include turning on a feature

Since getrandom is a transitive dependency, I have to go through this crate's features for that